### PR TITLE
Change examples to actual working examples, refactor and fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ from pprint import pprint
 # Structure payload.
 payload = {
     'source': 'amazon',
-    'url': 'https://www.amazon.co.uk/dp/AA12345678',
+    'url': 'https://www.amazon.co.uk/dp/B0BDJ279KF',
     'parse': True
 }
 
@@ -159,11 +159,11 @@ from pprint import pprint
 payload = {
     'source': 'amazon_product',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
     'context': [
     {
-      'key': 'autoselect_variant', 'value': true
+      'key': 'autoselect_variant', 'value': True
     }],
 }
 
@@ -216,7 +216,7 @@ from pprint import pprint
 payload = {
     'source': 'amazon_pricing',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
 }
 
@@ -267,7 +267,7 @@ from pprint import pprint
 payload = {
     'source': 'amazon_reviews',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
 }
 
@@ -316,7 +316,7 @@ from pprint import pprint
 payload = {
     'source': 'amazon_questions',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
 }
 
@@ -367,12 +367,12 @@ from pprint import pprint
 # Structure payload.
 payload = {
     'source': 'amazon_bestsellers',
-    'domain': 'com',
-    'query': 'Clothing, Shoes & Jewelry',
+    'domain': 'de',
+    'query': 'automotive',
     'start_page': 2,
     'parse': True,
     'context': [
-        {'key': 'category_id', 'value': 6127770011},
+        {'key': 'category_id', 'value': 82400031},
     ],
 }
 

--- a/code_examples/amazon.py
+++ b/code_examples/amazon.py
@@ -5,7 +5,7 @@ from pprint import pprint
 # Structure payload.
 payload = {
     'source': 'amazon',
-    'url': 'https://www.amazon.co.uk/dp/AA12345678',
+    'url': 'https://www.amazon.co.uk/dp/B0BDJ279KF',
     'parse': True
 }
 
@@ -13,7 +13,7 @@ payload = {
 response = requests.request(
     'POST',
     'https://realtime.oxylabs.io/v1/queries',
-    auth=('YOUR_USERNAME', 'YOUR_PASSWORD'), #Your credentials go here
+    auth=('user', 'pass1'),  # Your credentials go here
     json=payload,
 )
 

--- a/code_examples/amazon_bestsellers.py
+++ b/code_examples/amazon_bestsellers.py
@@ -4,15 +4,13 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_search',
-    'domain': 'nl',
-    'query': 'adidas',
-    'start_page': 11,
-    'pages': 10,
+    'source': 'amazon_bestsellers',
+    'domain': 'de',
+    'query': 'automotive',
+    'start_page': 2,
     'parse': True,
     'context': [
-        {'key': 'category_id', 'value': 16391843031},
-        {'key': 'merchant_id', 'value':'3AA17D2BRD4YMT0X'}
+        {'key': 'category_id', 'value': 82400031},
     ],
 }
 

--- a/code_examples/amazon_pricing.py
+++ b/code_examples/amazon_pricing.py
@@ -4,10 +4,10 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_sellers',
-    'domain': 'de',
-    'query': 'ABNP0A7Y0QWBN',
-    'parse': True
+    'source': 'amazon_pricing',
+    'domain': 'nl',
+    'query': 'B09RX4KS1G',
+    'parse': True,
 }
 
 

--- a/code_examples/amazon_product.py
+++ b/code_examples/amazon_product.py
@@ -1,19 +1,18 @@
 import requests
 from pprint import pprint
 
-
 # Structure payload.
 payload = {
-    'source': 'amazon_bestsellers',
-    'domain': 'com',
-    'query': 'Clothing, Shoes & Jewelry',
-    'start_page': 2,
+    'source': 'amazon_product',
+    'domain': 'nl',
+    'query': 'B09RX4KS1G',
     'parse': True,
     'context': [
-        {'key': 'category_id', 'value': 6127770011},
+        {
+            'key': 'autoselect_variant', 'value': True
+        },
     ],
 }
-
 
 # Get response.
 response = requests.request(

--- a/code_examples/amazon_questions.py
+++ b/code_examples/amazon_questions.py
@@ -4,9 +4,9 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_pricing',
+    'source': 'amazon_questions',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
 }
 

--- a/code_examples/amazon_reviews.py
+++ b/code_examples/amazon_reviews.py
@@ -4,9 +4,9 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_questions',
+    'source': 'amazon_reviews',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'B09RX4KS1G',
     'parse': True,
 }
 

--- a/code_examples/amazon_search.py
+++ b/code_examples/amazon_search.py
@@ -4,10 +4,16 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_reviews',
+    'source': 'amazon_search',
     'domain': 'nl',
-    'query': 'AA12345678',
+    'query': 'adidas',
+    'start_page': 11,
+    'pages': 10,
     'parse': True,
+    'context': [
+        {'key': 'category_id', 'value': 16391843031},
+        {'key': 'merchant_id', 'value': '3AA17D2BRD4YMT0X'}
+    ],
 }
 
 

--- a/code_examples/amazon_sellers.py
+++ b/code_examples/amazon_sellers.py
@@ -4,14 +4,10 @@ from pprint import pprint
 
 # Structure payload.
 payload = {
-    'source': 'amazon_product',
-    'domain': 'nl',
-    'query': 'AA12345678',
-    'parse': True,
-    'context': [
-    {
-      'key': 'autoselect_variant', 'value': true
-    }],
+    'source': 'amazon_sellers',
+    'domain': 'de',
+    'query': 'ABNP0A7Y0QWBN',
+    'parse': True
 }
 
 


### PR DESCRIPTION
Almost none of the provided examples work (i.e. the targets are 404), also there was a syntax error in amazon_product example (`True` bool value was written as `true`), missing newlines at the end of most files. Also using spaces in directory names is bad practice so renamed `code examples` to `code_examples`.